### PR TITLE
Fix use of `the_content` filter

### DIFF
--- a/public/class-tipi-public.php
+++ b/public/class-tipi-public.php
@@ -119,11 +119,14 @@ class Tipi_Public {
 
 	public function insert_tipi_content( $content ) {
 		if ( $this->is_tipi_page() && $this->tipi_gateway_settings_options['where_to_display_it_2'] == get_the_ID() ) {
+			//$content is accessible in your own template too
 			$templateFile = apply_filters('tipi_gateway_public_template','partials/tipi-public-display.php');
+			ob_start();
 			include_once $templateFile;
-			return null;
+			$new_content = ob_get_clean();
+			return $new_content;
 		}
-			return $content;
+		return $content;
 	}
 
 	/**

--- a/public/class-tipi-public.php
+++ b/public/class-tipi-public.php
@@ -122,10 +122,11 @@ class Tipi_Public {
 			//$content is accessible in your own template too
 			$templateFile = apply_filters('tipi_gateway_public_template','partials/tipi-public-display.php');
 			ob_start();
-			include_once $templateFile;
+			include $templateFile;
 			$new_content = ob_get_clean();
 			return $new_content;
 		}
+		
 		return $content;
 	}
 


### PR DESCRIPTION
`the content` filter should return something because it can be use multiple times in the displayed page, so we use `ob_start()` to capture the output and send it to a var and return it instead of displaying the template while the_content is called.